### PR TITLE
Fix SELinux Read/Write Mount Point

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,17 @@
-.git
-.vagrant
-goss.d
+# directories
+.git/
+.vagrant/
+goss.d/
+roles/
 
+# files
+.gitignore
 .travis.yml
-Makefile
-README.md
-Vagrantfile
 ansible.cfg
 goss.yml
+Makefile
+README.md
+requirements.yml
+test.yml
 vagrant.yml
+Vagrantfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ RUN apt-add-repository -y ppa:ansible/ansible >/dev/null \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean >/dev/null
 
+# provide selinux remount command; see https://github.com/naftulikay/docker-trusty-vm/issues/6
+RUN sed -i 's/exit 0//g' /etc/rc.local \
+  && ANSIBLE_FORCE_COLOR=yes ansible -i 127.0.0.1, -c local all -m blockinfile -a \
+    'path=/etc/rc.local block="mountpoint -q /sys/fs/selinux && mount -o remount,ro /sys/fs/selinux || true"'
+
 # install our wait-for-boot script
 COPY bin/wait-for-boot /usr/bin/wait-for-boot
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,15 @@ This container **must** do the following:
 
  - :ballot_box_with_check: enable services to be started via the init manager using `service $x start`.
 
+#### Mounts
+
+ - :ballot_box_with_check: `/sys/fs/selinux`, [if present][docker-privileged-selinux], will be remounted read-only to
+    allow most programs to work.
+
  [docker]: https://hub.docker.com/r/naftulikay/trusty-vm/
  [svg-docker]: https://img.shields.io/docker/automated/naftulikay/trusty-vm.svg?maxAge=2592000
  [travis]: https://travis-ci.org/naftulikay/docker-trusty-vm
  [svg-travis]: https://travis-ci.org/naftulikay/docker-trusty-vm.svg?branch=develop
  [post]: https://www.jeffgeerling.com/blog/2016/how-i-test-ansible-configuration-on-7-different-oses-docker
  [upstream]: https://hub.docker.com/r/geerlingguy/docker-ubuntu1404-ansible/
+ [docker-privileged-selinux]: https://twitter.com/naftulikay/status/875539799599235072

--- a/bin/wait-for-boot
+++ b/bin/wait-for-boot
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
+# In Docker without --privileged, runlevel will return 'unknown'; with --privileged, it seems to return a max of 2
+required_runlevel=2
+
 function .is-booted() {
   local current_runlevel="$(runlevel | awk '{print $2;}')"
-  test "${current_runlevel}" == "5" -o -z "${current_runlevel}"
+  test "${current_runlevel}" == "${required_runlevel}" -o -z "${current_runlevel}"
   return $?
 }
 
@@ -15,16 +18,18 @@ function .await-boot() {
   while ! .is-booted && [ $i -lt $max_retries ]; do
     iteration=$(($i + 1)) # the nth iteration, one-based
 
-    printf "[%02d/%02d] waiting %ds for system to reach runlevel 5...\n" $iteration $max_retries $sleep_time
+    printf "[%02d/%02d] waiting %ds for system to reach runlevel ${required_runlevel}...\n" \
+      $iteration $max_retries $sleep_time
+
     sleep $sleep_time
 
     i=$iteration
   done
 
   if .is-booted ; then
-    echo "Host has reached runlevel 5."
+    echo "Host has reached runlevel ${required_runlevel}."
   else
-    echo "ERROR: Host failed to reach runlevel 5." >&2
+    echo "ERROR: Host failed to reach runlevel ${required_runlevel}." >&2
     return 1
   fi
 }

--- a/goss.d/mounts.yml
+++ b/goss.d/mounts.yml
@@ -1,0 +1,9 @@
+---
+{{ if and (eq .Env.privileged "true") (eq .Env.selinux_host "true") }}
+# if we are in privileged mode and the host is an SELinux host, then check the mount
+# see: https://twitter.com/naftulikay/status/875539799599235072
+mount:
+  '/sys/fs/selinux':
+    exists: true
+    opts: { contain-element: "ro" }
+{{ end }}

--- a/goss.d/packages.yml
+++ b/goss.d/packages.yml
@@ -2,3 +2,6 @@
 package:
   less:
     installed: true
+
+  ntp:
+    installed: true

--- a/goss.d/services.yml
+++ b/goss.d/services.yml
@@ -1,1 +1,5 @@
 ---
+service:
+  ntp:
+    running: true
+    enabled: true

--- a/goss.yml
+++ b/goss.yml
@@ -1,7 +1,3 @@
 ---
 gossfile:
-  "goss.d/files.yml": {}
-  "goss.d/host.yml": {}
-  "goss.d/packages.yml": {}
-  "goss.d/services.yml": {}
-  "goss.d/time.yml": {}
+  "goss.d/*.yml": {}

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
  - name: degoss
    src: naftulikay.degoss
-   version: v1.1.2
+   version: v1.2.1

--- a/test.yml
+++ b/test.yml
@@ -1,8 +1,27 @@
 ---
+- name: demonstrate system capabilities
+  hosts: all
+  become: true
+  tasks:
+    - name: install ntp package
+      apt: name=ntp state=present cache_valid_time=3600
+
+    - name: start and enable ntp service
+      service: name=ntp state=started enabled=true
+
 - name: goss tests
   hosts: all
   become: true
+  vars:
+    # is the container and the host running selinux
+    selinux_host: false
+    privileged: false
   roles:
     - role: degoss
       goss_file: goss.yml
       goss_addtl_dirs: [goss.d/]
+      degoss_dump_output: true
+      degoss_no_clean: true
+      goss_env_vars:
+        selinux_host: "{{ selinux_host | mandatory | bool }}"
+        privileged: "{{ privileged | mandatory | bool }}"


### PR DESCRIPTION
This was an issue for naftulikay/xenial-vm as well, basically on SELinux Docker hosts, Docker containers get /sys/fs/selinux mounted read/write. Since this is largely a farce, everything freaks out on Ubuntu machines and it won't handle it well.

This fixes that by adding an early stage script to remount the filesystem in read-only mode at a very early boot stage. This will allow Ansible to install packages, etc.

Closes #6.

#### Acceptance Criteria

 - [x] `/sys/fs/selinux` should be remounted read-only during an early boot stage.
 - [x] Goss tests must prove that package installation works inside the VM.
 - [x] Goss tests must prove that service starting/enabling works inside the VM.
 - [x] The README.md contract must be extended to document these improvements.